### PR TITLE
Prototype of glance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,24 @@ glance is a Chrome extension which estimates the gender breakdown in an employee
 
 When reviewing LinkedIn company/people pages, use this tool to scan the page and provide an estimated breakdown of gender representation.
 
-
-
 - [Example mockup](https://drive.google.com/file/d/1JG41iUVfuIp8H1LiEZZwywroDY0X4OhD/view?usp=sharing)
 - [Closeup](https://drive.google.com/file/d/1ND0rH5U0Ywx5hpH-_Xo-8lvvIalKjpkU/view?usp=sharing)
 
-
 Help build glance by emailing [@thesarahcassidy](https://github.com/thesarahcassidy)
+
+## Development setup
+
+To install the extension from the source code:
+
+1. [Clone or download the GitHub repository][1]
+2. In Google Chrome, navigate to `chrome://extensions`
+3. Turn on the _developer mode_ switch.
+4. Click the _load unpacked_ button.
+5. Select the `glance/src` directory.
+
+After making changes to the code:
+
+1. In Google Chrome, navigate to `chrome://extensions`
+2. Click the _reload_ icon in the _glance_ card.
+
+[1]: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository

--- a/src/background.js
+++ b/src/background.js
@@ -1,0 +1,55 @@
+const TYPICALLY_MASCULINE_NAMES = new Set([
+  "adam",
+  "eric",
+  "kevin",
+  "rob"
+]);
+
+const TYPICALLY_FEMININE_NAMES = new Set([
+  "amanda",
+  "alice",
+  "sarah",
+  "jane"
+]);
+
+const guess = (name) => {
+  const lowerFirstName = name.split(/\s+/)[0].toLowerCase();
+  if (TYPICALLY_FEMININE_NAMES.has(lowerFirstName)) {
+    return "feminine";
+  }
+  if (TYPICALLY_MASCULINE_NAMES.has(lowerFirstName)) {
+    return "masculine";
+  }
+  return "unknown";
+};
+
+const guessMany = (names) => {
+  const guesses = {feminine: 0, masculine: 0, unknown: 0};
+  names.forEach((name) => {
+    guesses[guess(name)] += 1;
+  });
+  return guesses;
+};
+
+const enable = (tab) => {
+  if (tab) {
+    chrome.pageAction.show(tab.id);
+  }
+};
+
+const getGuesses = (sendResponse) => {
+  chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
+    chrome.tabs.sendMessage(tabs[0].id, {action: "getNames"}, (names) => {
+      sendResponse(guessMany(names));
+    });
+  });
+}
+
+chrome.runtime.onMessage.addListener(({action}, {tab}, sendResponse) => {
+  if (action == "enable") {
+    enable(tab);
+  } else if (action == "getGuesses") {
+    getGuesses(sendResponse);
+    return true;
+  }
+});

--- a/src/linkedin.js
+++ b/src/linkedin.js
@@ -1,0 +1,14 @@
+const Actions = {
+  getNames: () => {
+    const elements = document.
+      querySelectorAll(".org-people-profile-card__profile-title");
+    return Array.from(elements).map((element) => element.innerText);
+  }
+};
+
+chrome.runtime.onMessage.addListener(({action}, sender, sendResponse) => {
+  if (!Actions[action]) { return; }
+  sendResponse(Actions[action]());
+});
+
+chrome.runtime.sendMessage({action: "enable"});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,0 +1,26 @@
+{
+  "manifest_version": 2,
+  "name": "glance",
+  "version": "0.1",
+  "description": "glance estimates the gender breakdown in an employee list on LinkedIn",
+  "background": {
+    "scripts": [
+      "background.js"
+    ],
+    "persistent": false
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "https://*.linkedin.com/*"
+      ],
+      "js": [
+        "linkedin.js"
+      ]
+    }
+  ],
+  "page_action": {
+    "default_title": "glance",
+    "default_popup": "popup.html"
+  }
+}

--- a/src/popup.html
+++ b/src/popup.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>glance</title>
+  </head>
+  <body>
+    <h1>glance</h1>
+    <table>
+      <tr>
+        <td></td>
+        <th colspan="2">Names detected</th>
+      </tr>
+      <tr>
+        <th scope="row">Women's</th>
+        <td id="feminine-count" class="result"></td>
+        <td id="feminine-percentage" class="result"></td>
+      </tr>
+      <tr>
+        <th scope="row">Men's</th>
+        <td id="masculine-count" class="result"></td>
+        <td id="masculine-percentage" class="result"></td>
+      </tr>
+      <tr>
+        <th scope="row">Uncertain</th>
+        <td id="unknown-count" class="result"></td>
+        <td id="unknown-percentage" class="result"></td>
+      </tr>
+    </table>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,0 +1,18 @@
+const results = document.getElementById("results");
+
+document.querySelectorAll(".result").forEach((element) => element.innerHTML= "");
+
+chrome.runtime.sendMessage({action: "getGuesses"}, (guesses) => {
+  const totalGuesses = Object.values(guesses).
+    reduce((total, value) => total + value);
+
+  Object.keys(guesses).forEach((key) => {
+    const count = guesses[key];
+    const percentage = (totalGuesses > 0
+      ? Math.round(count / totalGuesses * 100)
+      : 0);
+
+    document.getElementById(`${key}-count`).innerText = count;
+    document.getElementById(`${key}-percentage`).innerText = `${percentage}%`;
+  });
+});


### PR DESCRIPTION
This commit provides a rough prototype of glance's functionality, based on @thesarahcassidy's mockup (see `README`). There is a toolbar button (a "page action") which is enabled on all LinkedIn pages.  When clicked, it shows a popup with a very rough guess at the gender breakdown of the people listed on the page.

![Screenshot of glance prototype](https://user-images.githubusercontent.com/35861/83463401-dd3cda80-a43b-11ea-8a77-ee7d157eec6f.png)

Gender identity is a complex and multifaceted thing -- certainly far more complex than checking a name against a list. The goal of this code is not to make accurate assertions about any individual's gender, but instead to provide a rough guess at the aggregate gender breakdown of the people working at a given company.

In addition, this prototype makes the very English-language-centric assumption that names can be broken down on spaces, and the first part is the person's given name.

The prototype has three main components:

- `linkedin.js` is injected into all pages on LinkedIn. On page load, it sends a message to the extension instructing it to enable the page action. It also listens for messages instructing it to extract a list of names from the page.

- `popup.html` / `popup.js` are the user interface that pops up when the browser toolbar button is clicked. On page load, it sends a message to the extension instructing it to guess at the gender breakdown of the names on the page.

- `background.js` orchestrates messages between the other components, and also does the guess work.